### PR TITLE
fix: reset file input on image replacement to ensure reupload trigger

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -232,6 +232,10 @@ export default function Home() {
                     onClick={() => {
                       setSelectedImage(null);
                       setDiagnosis(null);
+                      // Reset the file input or else reuploading the same image will not trigger handleFileChange
+                      if (fileInputRef.current) {
+                        fileInputRef.current.value = "";
+                      }
                     }}
                     disabled={isLoading}
                   >


### PR DESCRIPTION
I noticed that if I removed the image and tried to upload the same image again, the handleFileChange would not trigger.

I think this is the way to clear image file inputs but you do with the info what you'd like !